### PR TITLE
Update variational_formulations.md

### DIFF
--- a/variational_formulations.md
+++ b/variational_formulations.md
@@ -125,7 +125,7 @@ With these, we can establish existence.
 ```{admonition} Theorem: *Fundamental theorem of optimisation*
 :class: important
 
-Let $J : \mathcal{U} \rightarrow \mathbb{R}$ be proper, coercive, bounded from below and lower semi-continuous. Then $J$ has a minimiser.
+Let $J : \mathcal{U} \rightarrow \mathbb{R}$ be proper, coercive, bounded from below and sequential lower semi-continuous. Then $J$ has a minimiser.
 ```
 
 ```{admonition} Proof:


### PR DESCRIPTION
In the 'fundamental theorem of optimization' theorem, we had 'lower semi-continuity' but it should be 'sequential lower semi-continuity' (see proof in Lecture notes of Erhardt and Lang)