### PR TITLE
Update discrete_ip_regularization.md

### DIFF
--- a/discrete_ip_regularization.md
+++ b/discrete_ip_regularization.md
@@ -32,7 +32,7 @@ $$
 
 * If $m > n$ and $K$ has rank $n$, the system of equations may be *inconsistent* in which case a solution does not exist when $f$ is not in the range of $K$.
 
-* If $m < n$ and $K$ has rank $m$, we can always find a solution but it may not be unique because $K$ has a on-trivial *null-space*.
+* If $m < n$ and $K$ has rank $m$, we can always find a solution but it may not be unique because $K$ has a non-trivial *null-space*.
 
 * If $K$ does not have maximal rank, the system of equations may be both inconsistent and $K$ can have a null-space.
 


### PR DESCRIPTION
When $m < n $ i.e. full row rank but not full column rank, the null space is non-trivial